### PR TITLE
Add -Wno-error to compile with global -Werror

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -25,6 +25,7 @@ LOCAL_SRC_FILES := cashsvr.c cashsvr_input.c expatparser.c
 LOCAL_C_INCLUDES := external/expat/lib
 LOCAL_SHARED_LIBRARIES := liblog libcutils libexpat libpolyreg
 LOCAL_MODULE := cashsvr
+LOCAL_CFLAGS := -Wno-error
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_OWNER := sony
 LOCAL_INIT_RC_64   := vendor/etc/init/cashsvr.rc

--- a/cash_ctl.c
+++ b/cash_ctl.c
@@ -39,7 +39,7 @@
 
 static int32_t send_cashsvr_data(struct cash_params params)
 {
-	register int sock, recvsock;
+	register int sock, __attribute__((unused))recvsock;
 	int ret, len = sizeof(struct sockaddr_un);
 	int32_t cashsvr_reply;
 	fd_set receivefd;


### PR DESCRIPTION
needed to supress errors in build on android pie

Signed-off-by: David Viteri <davidteri91@gmail.com>