### PR TITLE
Fix LOG_TAG macro redefined warning properly.

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -29,7 +29,6 @@ LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_OWNER := sony
 LOCAL_INIT_RC_64   := vendor/etc/init/cashsvr.rc
 LOCAL_PROPRIETARY_MODULE := true
-LOCAL_CFLAGS += -Wno-macro-redefined
 include $(BUILD_EXECUTABLE)
 
 include $(CLEAR_VARS)

--- a/cashsvr.c
+++ b/cashsvr.c
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#define LOG_TAG			"CASH"
+
 #include <cutils/properties.h>
 #include <sys/types.h>
 #include <sys/stat.h>
@@ -39,8 +41,6 @@
 #include "cash_private.h"
 #include "cash_input.h"
 #include "cash_ext.h"
-
-#define LOG_TAG			"CASH"
 
 #define UNUSED __attribute__((unused))
 

--- a/cashsvr_input.c
+++ b/cashsvr_input.c
@@ -17,6 +17,8 @@
  * limitations under the License.
  */
 
+#define LOG_TAG			"CASH_INPUT"
+
 #include <sys/poll.h>
 #include <sys/epoll.h>
 #include <sys/types.h>
@@ -43,8 +45,6 @@
 #include "cash_private.h"
 #include "cash_input.h"
 #include "cash_ext.h"
-
-#define LOG_TAG			"CASH_INPUT"
 
 #define VL53L0_EVT		"/dev/input/event1"
 #define VL53L0_STR		"STM VL53L0 proximity sensor"

--- a/expatparser.c
+++ b/expatparser.c
@@ -19,6 +19,8 @@
  * limitations under the License.
  */
 
+#define LOG_TAG "CASH-XMLParser"
+
 #include <errno.h>
 #include <string.h>
 #include <stdlib.h>
@@ -35,8 +37,6 @@
 #include <log/log.h>
 
 #define UNUSED __attribute__((unused))
-
-#define LOG_TAG "CASH-XMLParser"
 
 #define CASH_MAX_FOCTBL_ENTRIES	500
 
@@ -121,7 +121,7 @@ void str_handler(void *data, const char *str, int len)
 	data = (void*)buf;
 }
 
-int parse_cash_xml_data(char* filepath, char* node, 
+int parse_cash_xml_data(char* filepath, char* node,
 			struct cash_focus_params *cash_focus,
 			struct cash_configuration *cash_config)
 {


### PR DESCRIPTION
This reverts commit 05e140369baf3ef98a837ea50b8e44be645b4b90 and fixes the redefinitions properly, rather than hiding the warning.

Tested with `m cashsvr libcashctl`, no `Macro redefined` warnings are thrown.