### PR TITLE
CASH: Introduce RGBC-IR sensor support

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -21,7 +21,7 @@ LOCAL_COPY_HEADERS := ./cash_ext.h
 include $(BUILD_COPY_HEADERS)
 
 include $(CLEAR_VARS)
-LOCAL_SRC_FILES := cashsvr.c cashsvr_input.c expatparser.c
+LOCAL_SRC_FILES := cashsvr.c cash_input_common.c cashsvr_input_tof.c cashsvr_input_rgbc.c expatparser.c
 LOCAL_C_INCLUDES := external/expat/lib
 LOCAL_SHARED_LIBRARIES := liblog libcutils libexpat libpolyreg
 LOCAL_MODULE := cashsvr

--- a/cash_input_common.c
+++ b/cash_input_common.c
@@ -1,0 +1,72 @@
+/*
+ * CASH! Camera Augmented Sensing Helper
+ * a multi-sensor camera helper server
+ *
+ * Input devices module
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include <sys/poll.h>
+#include <sys/epoll.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <pthread.h>
+
+#include <log/log.h>
+
+#include "cash_input_common.h"
+
+
+/* Start/stop threads */
+int cash_input_threadman(bool start, struct thread_data *thread_data)
+{
+	int ret = -1;
+	int thread_no = thread_data->thread_no;
+
+	if (start == false) {
+		cash_thread_run[thread_no] = false;
+		return 0;
+	};
+
+	cash_thread_run[thread_no] = true;
+
+	if (thread_no < THREAD_MAX) {
+		ret = pthread_create(&cash_pthreads[thread_no], NULL,
+				thread_data->thread_func, NULL);
+		if (ret != 0) {
+			ALOGE("Cannot create thread with number %d", thread_no);
+			return -ENXIO;
+		}
+	}
+
+	return ret;
+}
+
+int cash_set_parameter(char* path, char* value, int value_len) {
+	int fd, rc;
+
+	fd = open(path, O_WRONLY);
+	if (fd < 0) {
+		ALOGD("Cannot open %s", path);
+		return -1;
+	}
+
+	rc = write(fd, value, value_len);
+	if (rc < value_len) {
+		ALOGW("ERROR! Cannot write value %s to %s", value, path);
+		return -1;
+	}
+	close(fd);
+	return 0;
+}

--- a/cash_input_common.h
+++ b/cash_input_common.h
@@ -2,6 +2,8 @@
  * CASH! Camera Augmented Sensing Helper
  * a multi-sensor camera helper server
  *
+ * Input devices module
+ *
  * Copyright (C) 2018 AngeloGioacchino Del Regno <kholk11@gmail.com>
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -17,20 +19,36 @@
  * limitations under the License.
  */
 
-#ifndef CASHSVR_EXT_H
-#define CASHSVR_EXT_H
+#define ITERATE_MAX_DEVS	9
 
-struct exptime_iso_tpl {
-	int64_t exptime;
-	int32_t iso;
+enum thread_number {
+	THREAD_TOF,
+	THREAD_RGBC,
+	THREAD_MAX
 };
 
-int cash_tof_start(int value);
-int cash_is_tof_in_range(void);
-int32_t cash_get_focus(void);
 
-int cash_rgbc_start(int value);
-int cash_is_rgbc_in_range(void);
-struct exptime_iso_tpl cash_get_exptime_iso(void);
+enum fd_number {
+	FD_TOF,
+	FD_RGBC,
+	FD_MAX
+};
 
-#endif
+struct thread_data {
+	enum thread_number thread_no;
+	void *thread_func;
+};
+
+bool cash_thread_run[THREAD_MAX];
+pthread_t cash_pthreads[THREAD_MAX];
+struct pollfd cash_pfds[FD_MAX];
+struct epoll_event cash_pollevt[FD_MAX];
+int cash_pollfd[FD_MAX];
+int cash_pfdelay_ms[FD_MAX];
+
+static const char sysfs_input_str[] = "/sys/class/input/input";
+static const char devfs_input_str[] = "/dev/input/event";
+
+int cash_input_threadman(bool start, struct thread_data *thread_data);
+int cash_set_parameter(char* path, char* value, int value_len);
+

--- a/cash_input_rgbc.h
+++ b/cash_input_rgbc.h
@@ -2,7 +2,10 @@
  * CASH! Camera Augmented Sensing Helper
  * a multi-sensor camera helper server
  *
+ * Input devices module
  * Copyright (C) 2018 AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * RGBC-IR module
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,20 +20,16 @@
  * limitations under the License.
  */
 
-#ifndef CASHSVR_EXT_H
-#define CASHSVR_EXT_H
-
-struct exptime_iso_tpl {
-	int64_t exptime;
-	int32_t iso;
+struct cash_tcs3490 {
+	int red;
+	int green;
+	int blue;
+	int clear;
+	int ir;
 };
 
-int cash_tof_start(int value);
-int cash_is_tof_in_range(void);
-int32_t cash_get_focus(void);
+int cash_rgbc_read_inst(struct cash_tcs3490 *tcsvl_final);
+int cash_input_rgbc_start(bool start);
+bool cash_input_is_rgbc_alive(void);
+int cash_input_rgbc_init(void);
 
-int cash_rgbc_start(int value);
-int cash_is_rgbc_in_range(void);
-struct exptime_iso_tpl cash_get_exptime_iso(void);
-
-#endif

--- a/cash_input_tof.h
+++ b/cash_input_tof.h
@@ -1,6 +1,6 @@
 /*
- * Micro Communicator for Projection uC
- * a High-Speed Serial communications server
+ * CASH! Camera Augmented Sensing Helper
+ * a multi-sensor camera helper server
  *
  * Input devices module
  *
@@ -33,11 +33,6 @@ struct cash_vl53l0 {
 	int measure_mode;
 };
 
-enum {
-	THREAD_TOF,
-	THREAD_MAX
-};
-
 int cash_input_tof_read(struct cash_vl53l0 *stmvl_cur,
 	uint16_t want_code);
 int cash_tof_read_stabilized(
@@ -48,7 +43,6 @@ int cash_tof_thr_read_stabilized(
 	struct cash_vl53l0 *stmvl_final,
 	int runs, int nmatch, int sleep_ms, int hyst);
 int cash_input_tof_start(bool start);
-int cash_input_threadman(bool start, int threadno);
 bool cash_input_is_tof_alive(void);
 int cash_input_tof_init(void);
 

--- a/cash_private.h
+++ b/cash_private.h
@@ -24,30 +24,27 @@
 #define CASHSERVER_SOCKET		CASHSERVER_DIR "cashsvr"
 #define CASHSERVER_MAXCONN		10
 
-#define CASHSERVER_CONF_FILE		"/vendor/etc/tof_focus_calibration.xml"
+#define CASHSERVER_TOF_CONF_FILE	"/vendor/etc/tof_focus_calibration.xml"
+#define CASHSERVER_RGBC_CONF_FILE	"/vendor/etc/cash_expcol_calibration.xml"
 
 typedef enum {
 	OP_INITIALIZE = 0,
 	OP_TOF_START,
 	OP_CHECK_TOF_RANGE,
 	OP_FOCUS_GET,
+	OP_RGBC_START,
+	OP_CHECK_RGBC_RANGE,
+	OP_EXPTIME_ISO_GET,
 	OP_MAX,
 } cash_svr_ops_t;
 
-struct cash_cached_data {
-	bool light_suspended;
-	uint8_t light;
-	uint8_t focus;
-	uint8_t keystone;
-};
-
-struct cash_foctbl_entry {
+struct cash_polyreg_tbl_entry {
 	int32_t input_val;
-	int32_t focus_step;
+	int32_t output_val;
 };
 
-struct cash_focus_params {
-	struct cash_foctbl_entry *table;
+struct cash_polyreg_params {
+	struct cash_polyreg_tbl_entry *table;
 	unsigned int num_steps;
 	double *terms;
 };
@@ -57,10 +54,17 @@ struct cash_configuration {
 	int32_t tof_max;
 	int32_t tof_hyst;
 	int32_t tof_max_runs;
-	int32_t polyreg_degree;
-	int32_t polyreg_extra;
+	int32_t tof_polyreg_degree;
+	int32_t tof_polyreg_extra;
 	int8_t  use_tof_stabilized;
 	int8_t  disable_tof;
+	int32_t rgbc_clear_min;
+	int32_t rgbc_clear_max;
+	int32_t rgbc_polyreg_degree;
+	int32_t rgbc_polyreg_extra;
+	int8_t  disable_rgbc;
+	int64_t *exposure_times;
+	int32_t nexposure_times;
 };
 
 struct cash_focus_state {
@@ -74,8 +78,19 @@ struct cash_params {
 	int32_t value;
 };
 
-int parse_cash_xml_data(char* filepath, char* node, 
-			struct cash_focus_params *cash_focus,
+struct cash_response {
+	bool retval;
+	int32_t focus_step;
+	int64_t exptime;
+	int32_t iso;
+};
+
+int parse_cash_tof_xml_data(char* filepath, char* node, 
+			struct cash_polyreg_params *cash_focus,
+			struct cash_configuration *cash_config);
+
+int parse_cash_rgbc_xml_data(char* filepath, char* node, 
+			struct cash_polyreg_params *cash_rgbc_clear_iso,
 			struct cash_configuration *cash_config);
 
 #define REPLY_FOCUS_CUSTOM_LEN		7

--- a/cashsvr_input_rgbc.c
+++ b/cashsvr_input_rgbc.c
@@ -1,0 +1,447 @@
+/*
+ * CASH! Camera Augmented Sensing Helper
+ * a multi-sensor camera helper server
+ *
+ * RGBC-IR module
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define LOG_TAG			"CASH_RGBC_INPUT"
+
+#include <sys/poll.h>
+#include <sys/epoll.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+#include <pwd.h>
+#include <linux/input.h>
+
+#include <cutils/android_filesystem_config.h>
+#include <log/log.h>
+
+#include "cash_private.h"
+#include "cash_input_common.h"
+#include "cash_input_rgbc.h"
+#include "cash_ext.h"
+
+#define TCS3490_STR		"AMS TCS3490 Sensor"
+#define TCS3490_ALS_ITIME	"127"
+#define TCS3490_ALS_GAIN_LOW	"1"
+#define TCS3490_ALS_GAIN_MID	"4"
+#define TCS3490_ALS_GAIN_HIGH	"8"
+
+static int tcsvl_fd;
+
+static char *rgbc_chip_power_path;
+static char *rgbc_power_state_path;
+static char *rgbc_gain_path;
+static char *rgbc_Itime_path;
+static bool rgbc_enabled = false;
+
+struct cash_tcs3490 tcsvl_status;
+
+#define UNUSED __attribute__((unused))
+
+#define LEN_NAME	4
+#define LEN_CHIP_POW	8
+#define LEN_POWER_STATE	15
+#define LEN_ITIME	9
+#define LEN_GAIN	9
+
+int cash_rgbc_enable(bool enable)
+{
+	int rc;
+
+	if (rgbc_chip_power_path == NULL || rgbc_power_state_path == NULL)
+		return -1;
+
+	/* Reset the readings to start fresh */
+	tcsvl_status.red = -1;
+	tcsvl_status.green = -1;
+	tcsvl_status.blue = -1;
+	tcsvl_status.clear = -1;
+
+	/* enabling/disabling requires writing to sysfs twice
+	 * chip_power to power up/down the chip
+	 * als_power_state to start/stop the work
+	 */
+	if (enable) {
+		rc = cash_set_parameter(rgbc_chip_power_path, "1", 1);
+		if (!rc)
+			rc = cash_set_parameter(rgbc_power_state_path, "1", 1);
+		// set default gain and Itime if sensor was just enabled
+		if (!rc)
+			rc = cash_set_parameter(rgbc_gain_path, TCS3490_ALS_GAIN_LOW, 1);
+		if (!rc)
+			rc = cash_set_parameter(rgbc_Itime_path, TCS3490_ALS_ITIME, 3);
+	} else {
+		rc = cash_set_parameter(rgbc_power_state_path, "0", 1);
+		if (!rc)
+			rc = cash_set_parameter(rgbc_chip_power_path, "0", 1);
+	}
+
+	if (rc) {
+		ALOGW("ERROR! Cannot %sable RGBC!", enable ? "en" : "dis");
+		goto end;
+	}
+
+	rc = 0;
+
+end:
+	usleep(100000);
+	rgbc_enabled = enable;
+
+	return rc;
+}
+
+static int cash_rgbc_sys_init(int devno, int plen)
+{
+	struct passwd *pwd;
+	struct passwd *grp;
+	uid_t uid;
+	gid_t gid;
+
+	// get system user and input group to call chown
+	pwd = getpwnam("system");
+	if (pwd == NULL) {
+		ALOGD("failed to get uid for system");
+		return 1;
+	}
+	uid = pwd->pw_uid;
+
+	grp = getpwnam("input");
+	if (grp == NULL) {
+		ALOGD("failed to get gid for input");
+		return 1;
+	}
+	gid = grp->pw_gid;
+
+	// allocate memory for all paths needed
+	rgbc_chip_power_path = (char*)calloc(plen + LEN_CHIP_POW, sizeof(char));
+	if (rgbc_chip_power_path == NULL) {
+		ALOGE("Memory exhausted. Cannot allocate.");
+		return -3;
+	}
+
+	rgbc_power_state_path = (char*)calloc(plen + LEN_POWER_STATE, sizeof(char));
+	if (rgbc_power_state_path == NULL) {
+		ALOGE("Memory exhausted. Cannot allocate.");
+		return -3;
+	}
+
+	rgbc_Itime_path = (char*)calloc(plen + LEN_ITIME, sizeof(char));
+	if (rgbc_Itime_path == NULL) {
+		ALOGE("Memory exhausted. Cannot allocate.");
+		free(rgbc_Itime_path);
+		return -3;
+	}
+
+	rgbc_gain_path = (char*)calloc(plen + LEN_GAIN, sizeof(char));
+	if (rgbc_gain_path == NULL) {
+		ALOGE("Memory exhausted. Cannot allocate.");
+		free(rgbc_gain_path);
+		return -3;
+	}
+
+	// populate the paths
+	snprintf(rgbc_chip_power_path, plen + LEN_CHIP_POW,
+		"%s%d/chip_pow", sysfs_input_str, devno);
+	snprintf(rgbc_power_state_path, plen + LEN_POWER_STATE,
+		"%s%d/als_power_state", sysfs_input_str, devno);
+	snprintf(rgbc_Itime_path, plen + LEN_ITIME,
+		"%s%d/als_Itime", sysfs_input_str, devno);
+	snprintf(rgbc_gain_path, plen + LEN_GAIN,
+		"%s%d/als_gain", sysfs_input_str, devno);
+
+	
+	// call chown on the paths to allow access after context switch
+	if (chown(rgbc_chip_power_path, uid, gid) == -1) {
+		ALOGD("Cannot chown %s", rgbc_chip_power_path);
+		return 1;
+	}
+	if (chown(rgbc_power_state_path, uid, gid) == -1) {
+		ALOGD("Cannot chown %s", rgbc_power_state_path);
+		return 1;
+	}
+	if (chown(rgbc_Itime_path, uid, gid) == -1) {
+		ALOGD("Cannot chown %s/als_Itime", rgbc_Itime_path);
+		return 1;
+	}
+	if (chown(rgbc_gain_path, uid, gid) == -1) {
+		ALOGD("Cannot chown %s/als_gain", rgbc_gain_path);
+		return 1;
+	}
+
+	return 0;
+}
+
+/* TODO: Use IOCTL EVIOCGNAME as a waaaay better way */
+static int cash_input_rgbc_find_inputdev(int maxdevs, int idev_len, char* idev_name)
+{
+	int fd, plen, rlen, rc, i;
+	int plen_xtra = 3;
+	char buf[254];
+	char* path;
+
+	/*
+	 * Avoid checking more than 99 input devices,
+	 * because... really? :)
+	 */
+	if (maxdevs > 99)
+		return -1;
+
+	if (maxdevs > 9)
+		plen_xtra++;
+
+	plen = strlen(sysfs_input_str) + plen_xtra;
+	path = (char*) calloc(plen + LEN_NAME, sizeof(char));
+	if (path == NULL) {
+		ALOGE("Out of memory. Cannot allocate.");
+		rc = -1;
+		goto end;
+	}
+
+	for (i = 0; i <= maxdevs; i++) {
+		rc = snprintf(path, plen + LEN_NAME, "%s%d/name",
+							sysfs_input_str, i);
+
+		if (fd > 0)
+			close(fd);
+
+		fd = open(path, (O_RDONLY | O_NONBLOCK));
+		if (fd < 0) {
+			ALOGD("Cannot open %s", path);
+			continue;
+		}
+
+		rlen = read(fd, buf, idev_len);
+		if (!rlen)
+			continue;
+
+		/*
+		 * If the string length doesn't match, avoid doing
+		 * expensive stuff, as the string cannot be the same.
+		 * Also consider some mistakes and compare it with
+		 * the name length - 1.
+		 * That will cover corner cases and will not evaluate
+		 * erroneously positive too many times...
+		 */
+		if (rlen < idev_len - 1)
+			continue;
+
+		rc = strncmp(buf, idev_name, idev_len - 1);
+		if (rc == 0) {
+			close(fd);
+
+			rc = cash_rgbc_sys_init(i, plen);
+			if (rc < 0)
+				goto end;
+
+			return i;
+		}
+	}
+end:
+	return rc;
+}
+
+int cash_input_rgbc_thr_read(struct cash_tcs3490 *tcsvl_cur,
+			int rgbc_fd)
+{
+	struct input_event evt[16];
+	int i, len, rc;
+	uint16_t type, code;
+	int32_t value;
+
+	rc = read(rgbc_fd, &evt, sizeof(evt));
+	if (!rc) {
+		return rc;
+	}
+
+	len = rc / sizeof(struct input_event);
+
+	for (i = 0; i < len; i++) {
+		type = evt[i].type;
+		code = evt[i].code;
+		value = evt[i].value;
+
+		switch (code) {
+			case ABS_MISC:
+				if (value >= 0) {
+					tcsvl_cur->clear = value;
+				}
+				break;
+			case ABS_HAT0X:
+				if (value >= 0) {
+					tcsvl_cur->red = value;
+				}
+				break;
+			case ABS_HAT0Y:
+				if (value >= 0) {
+					tcsvl_cur->green = value;
+				}
+				break;
+			case ABS_HAT1X:
+				if (value >= 0) {
+					tcsvl_cur->blue = value;
+				}
+				break;
+			case ABS_HAT1Y:
+				if (value >= 0) {
+					tcsvl_cur->ir = value;
+				}
+				break;
+			default:
+				break;
+		}
+	}
+
+	ALOGV("RGBC VALUES R:%d G:%d B:%d C:%d IR:%d", tcsvl_cur->red, tcsvl_cur->green, tcsvl_cur->blue, tcsvl_cur->clear, tcsvl_cur->ir);
+	return 0;
+}
+
+int cash_rgbc_read_inst(struct cash_tcs3490 *tcsvl_final)
+{
+	/* Thread not running, we'd read nothing good here! */
+	if (!cash_thread_run[THREAD_RGBC])
+		return -1;
+
+	/* Sensor is disabled, what are we trying to read?! */
+	if (!rgbc_enabled)
+		return -1;
+
+	/* No reading available */
+	if (tcsvl_status.clear < 0) {
+		ALOGE("ToF: No reading! clear %d", tcsvl_status.clear);
+		return -1;
+	}
+
+	tcsvl_final->clear = tcsvl_status.clear;
+
+	/* Return a fake score of 1 */
+	return 1;
+}
+
+static void cash_input_rgbc_thread(void)
+{
+	int ret;
+	int i;
+	struct epoll_event pevt[10];
+
+	cash_rgbc_enable(true);
+
+	ALOGD("RGBC Thread started");
+
+	while (cash_thread_run[THREAD_RGBC]) {
+		ret = epoll_wait(cash_pollfd[FD_RGBC], pevt,
+					10, cash_pfdelay_ms[FD_RGBC]);
+		for (i = 0; i < ret; i++) {
+			if (pevt[i].events & EPOLLERR ||
+			    pevt[i].events & EPOLLHUP ||
+			    !(pevt[i].events & EPOLLIN))
+				continue;
+
+			if (cash_pollevt[FD_RGBC].data.fd)
+				cash_input_rgbc_thr_read(&tcsvl_status,
+					cash_pollevt[FD_RGBC].data.fd);
+		}
+	}
+
+	cash_rgbc_enable(false);
+
+	pthread_exit((void*)((int)0));
+}
+
+struct thread_data cash_rgbc_thread_data = {
+	.thread_no = THREAD_RGBC,
+	.thread_func = cash_input_rgbc_thread
+};
+
+int cash_input_rgbc_start(bool start)
+{
+	return cash_input_threadman(start, &cash_rgbc_thread_data);
+}
+
+bool cash_input_is_rgbc_alive(void)
+{
+	return cash_thread_run[THREAD_RGBC];
+}
+
+int cash_input_rgbc_init(void)
+{
+	int dlen, evtno, rc;
+	char *devname, *devpath;
+
+	dlen = strlen(TCS3490_STR);
+	devname = (char*) calloc(dlen, sizeof(char));
+	snprintf(devname, dlen, "%s", TCS3490_STR);
+
+	evtno = cash_input_rgbc_find_inputdev(ITERATE_MAX_DEVS, dlen, devname);
+	if (evtno < 0)
+		return -1;
+
+	dlen = strlen(devfs_input_str) + 3;
+	if (evtno > 9)
+		dlen++;
+
+	devpath = (char*) calloc(dlen, sizeof(char));
+	if (devpath == NULL)
+		return -1;
+
+	snprintf(devpath, dlen, "%s%d", devfs_input_str, evtno);
+
+
+	tcsvl_fd = open(devpath, (O_RDONLY | O_NONBLOCK));
+	if (tcsvl_fd < 0) {
+		ALOGE("Error: cannot open the %s input device at %s.",
+			devname, devpath);
+		return -1;
+	}
+
+	cash_pollfd[FD_RGBC] = epoll_create1(0);
+	if (cash_pollfd[FD_RGBC] == -1) {
+		ALOGE("Error: Cannot create epoll descriptor");
+		return -1;
+	}
+
+	cash_pfds[FD_RGBC].fd = tcsvl_fd;
+	cash_pfds[FD_RGBC].events = POLLIN;
+	cash_pfdelay_ms[FD_RGBC] = 1000;
+
+	cash_pollevt[FD_RGBC].events = POLLIN;
+	cash_pollevt[FD_RGBC].data.fd = tcsvl_fd;
+
+	rc = epoll_ctl(cash_pollfd[FD_RGBC], EPOLL_CTL_ADD,
+					tcsvl_fd, &cash_pollevt[FD_RGBC]);
+	if (rc) {
+		ALOGE("Cannot add epoll control");
+		return -1;
+	}
+
+	cash_thread_run[THREAD_RGBC] = false;
+
+	return 0;
+}
+

--- a/expatparser.c
+++ b/expatparser.c
@@ -38,7 +38,7 @@
 
 #define UNUSED __attribute__((unused))
 
-#define CASH_MAX_FOCTBL_ENTRIES	500
+#define CASH_MAX_POLYREG_TBL_ENTRIES	500
 
 static short xml_depth = 0;
 static short parse = -1;
@@ -47,9 +47,15 @@ static char* main_node;
 static char millimeters[255];
 static char focus_steps[255];
 static char tof_min[50], tof_max[50], tof_hyst[4], tof_max_runs[4];
-static char polyreg_degree[3], polyreg_extra[3];
+static char tof_polyreg_degree[3], tof_polyreg_extra[3];
+static char clear_values[255];
+static char iso_values[255];
+static char exposure_times[255];
+static char rgbc_clear_min[50], rgbc_clear_max[50];
+static char rgbc_polyreg_degree[3], rgbc_polyreg_extra[3];
 
-struct cash_focus_params focus_params;
+struct cash_polyreg_params focus_params;
+struct cash_polyreg_params clear_iso_params;
 
 void parseElm(const char *elm, const char **attr)
 {
@@ -67,9 +73,9 @@ void parseElm(const char *elm, const char **attr)
 	if (strcmp("polyreg_tuning", elm) == 0) {
 		for (i = 0; attr[i]; i += 2) {
 			if (strcmp("degree", attr[i]) == 0)
-				strcpy(polyreg_degree, attr[i+1]);
+				strcpy(tof_polyreg_degree, attr[i+1]);
 			else if (strcmp("extra", attr[i]) == 0)
-				strcpy(polyreg_extra, attr[i+1]);
+				strcpy(tof_polyreg_extra, attr[i+1]);
 		}
 	}
 
@@ -88,6 +94,35 @@ void parseElm(const char *elm, const char **attr)
 				strcpy(tof_hyst, attr[i+1]);
 			else if (strcmp("max_runs", attr[i]) == 0)
 				strcpy(tof_max_runs, attr[i+1]);
+		}
+	}
+
+	if (strcmp("rgbc_clear_iso_exptime", elm) == 0) {
+		for (i = 0; attr[i]; i += 2) {
+			if (strcmp("clear_values", attr[i]) == 0)
+				strcpy(clear_values, attr[i+1]);
+			else if (strcmp("iso_values", attr[i]) == 0)
+				strcpy(iso_values, attr[i+1]);
+			else if (strcmp("exposure_times", attr[i]) == 0)
+				strcpy(exposure_times, attr[i+1]);
+		}
+	}
+
+	if (strcmp("rgbc_clear_limits", elm) == 0) {
+		for (i = 0; attr[i]; i += 2) {
+			if (strcmp("min_range", attr[i]) == 0)
+				strcpy(rgbc_clear_min, attr[i+1]);
+			else if (strcmp("max_range", attr[i]) == 0)
+				strcpy(rgbc_clear_max, attr[i+1]);
+		}
+	}
+
+	if (strcmp("rgbc_polyreg_tuning", elm) == 0) {
+		for (i = 0; attr[i]; i += 2) {
+			if (strcmp("degree", attr[i]) == 0)
+				strcpy(rgbc_polyreg_degree, attr[i+1]);
+			else if (strcmp("extra", attr[i]) == 0)
+				strcpy(rgbc_polyreg_extra, attr[i+1]);
 		}
 	}
 }
@@ -121,15 +156,15 @@ void str_handler(void *data, const char *str, int len)
 	data = (void*)buf;
 }
 
-int parse_cash_xml_data(char* filepath, char* node,
-			struct cash_focus_params *cash_focus,
+int parse_cash_tof_xml_data(char* filepath, char* node,
+			struct cash_polyreg_params *cash_focus,
 			struct cash_configuration *cash_config)
 {
 	int ret, fd, count, sz, tmp;
 	char *buf, *mend, *fend;
 	struct stat st;
 	XML_Parser pa;
-	struct cash_foctbl_entry *tbl_entry = NULL;
+	struct cash_polyreg_tbl_entry *tbl_entry = NULL;
 
 	fd = open(filepath, O_RDONLY);
 	if (fd < 0) {
@@ -159,8 +194,8 @@ int parse_cash_xml_data(char* filepath, char* node,
 		goto end;
 	}
 
-	focus_params.table = malloc(CASH_MAX_FOCTBL_ENTRIES *
-			sizeof(struct cash_foctbl_entry));
+	focus_params.table = malloc(CASH_MAX_POLYREG_TBL_ENTRIES *
+			sizeof(struct cash_polyreg_tbl_entry));
 	if (focus_params.table == NULL) {
 		ALOGE("Out of memory. Cannot allocate.");
 		ret = -ENOMEM;
@@ -185,9 +220,9 @@ int parse_cash_xml_data(char* filepath, char* node,
 	tbl_entry = &focus_params.table[focus_params.num_steps];
 
 	tbl_entry->input_val = (int32_t)strtol(millimeters, &mend, 10);
-	tbl_entry->focus_step = (int32_t)strtol(focus_steps, &fend, 10);
+	tbl_entry->output_val = (int32_t)strtol(focus_steps, &fend, 10);
 
-	if (tbl_entry->input_val == 0 || tbl_entry->focus_step == 0) {
+	if (tbl_entry->input_val == 0 || tbl_entry->output_val == 0) {
 		ret = -EINVAL;
 		free(focus_params.table);
 		goto end;
@@ -198,13 +233,13 @@ int parse_cash_xml_data(char* filepath, char* node,
 		tbl_entry = &focus_params.table[focus_params.num_steps];
 
 		tbl_entry->input_val = (int)strtol(mend, &mend, 10);
-		tbl_entry->focus_step = (int)strtol(fend, &fend, 10);
+		tbl_entry->output_val = (int)strtol(fend, &fend, 10);
 
 		/* We've reached the end, farewell! */
-		if (tbl_entry->input_val == 0 || tbl_entry->focus_step == 0) {
+		if (tbl_entry->input_val == 0 || tbl_entry->output_val == 0) {
 			break;
 		}
-	} while (focus_params.num_steps < CASH_MAX_FOCTBL_ENTRIES);
+	} while (focus_params.num_steps < CASH_MAX_POLYREG_TBL_ENTRIES);
 
 	/* All ok! */
 	cash_focus->num_steps = focus_params.num_steps;
@@ -231,19 +266,173 @@ int parse_cash_xml_data(char* filepath, char* node,
 		cash_config->tof_max_runs = tmp;
 	}
 
-	tmp = (int32_t)strtol(polyreg_degree, NULL, 10);
+	tmp = (int32_t)strtol(tof_polyreg_degree, NULL, 10);
 	if (tmp != 0) {
-		cash_config->polyreg_degree = tmp;
+		cash_config->tof_polyreg_degree = tmp;
 	}
 
-	tmp = (int32_t)strtol(polyreg_extra, NULL, 10);
+	tmp = (int32_t)strtol(tof_polyreg_extra, NULL, 10);
 	if (tmp != 0) {
-		cash_config->polyreg_extra = tmp;
+		cash_config->tof_polyreg_extra = tmp;
 	}
 
 end:
 	free(buf);
 secfail:
+	close(fd);
+	XML_ParserFree(pa);
+
+	return ret;
+}
+
+int parse_cash_rgbc_xml_data(char* filepath, char* node,
+			struct cash_polyreg_params *cash_rgbc_clear_iso,
+			struct cash_configuration *cash_config)
+{
+	int ret, fd, count, sz, tmp;
+	char *buf, *mend, *fend;
+	struct stat st;
+	XML_Parser pa;
+	struct cash_polyreg_tbl_entry *tbl_entry = NULL;
+	int64_t *exposure_time = NULL;
+
+	fd = open(filepath, O_RDONLY);
+	if (fd < 0) {
+		ALOGE("Cannot open configuration file!!!");
+		return -ENOENT;
+	}
+
+	pa = XML_ParserCreate(NULL);
+
+	stat(filepath, &st);
+	sz = st.st_size;
+
+	/* Security check: do NOT parse too big files */
+	if (sz > 131072) {
+		ALOGE("File is huge. Preventing parse as a security measure.");
+		ret = -E2BIG;
+		goto rgbc_secfail;
+	}
+
+	buf = malloc(sizeof(char)*sz);
+
+	memset(buf, 0, sz);
+	count = read(fd, buf, (sz - 1));
+	if (count < 0) {
+		ALOGE("Cannot read configuration file!!!");
+		ret = -EIO;
+		goto rgbc_end;
+	}
+
+	clear_iso_params.table = malloc(CASH_MAX_POLYREG_TBL_ENTRIES *
+			sizeof(struct cash_polyreg_tbl_entry));
+	if (clear_iso_params.table == NULL) {
+		ALOGE("Out of memory. Cannot allocate.");
+		ret = -ENOMEM;
+		goto rgbc_end;
+	}
+	clear_iso_params.num_steps = 0;
+
+	cash_config->exposure_times = malloc(CASH_MAX_POLYREG_TBL_ENTRIES *
+			sizeof(int64_t));
+	if (cash_config->exposure_times == NULL) {
+		ALOGE("Out of memory. Cannot allocate.");
+		ret = -ENOMEM;
+		goto rgbc_end;
+	}
+	cash_config->nexposure_times = 0;
+
+	XML_SetElementHandler(pa, startElm, endElm);
+	XML_SetCharacterDataHandler(pa, str_handler);
+
+	main_node = node;
+
+	if (XML_Parse(pa, buf, strlen(buf), XML_TRUE) == XML_STATUS_ERROR) {
+		ALOGE("XML Parse error: %s\n", XML_ErrorString(
+						XML_GetErrorCode(pa)));
+		ret = -EINVAL;
+		goto rgbc_end;
+	}
+	ret = 0;
+
+	/* Check values and fill the temporary struct */
+	tbl_entry = &clear_iso_params.table[clear_iso_params.num_steps];
+
+	tbl_entry->input_val = (int32_t)strtol(clear_values, &mend, 10);
+	tbl_entry->output_val = (int32_t)strtol(iso_values, &fend, 10);
+
+	if (tbl_entry->input_val == 0 || tbl_entry->output_val == 0) {
+		ret = -EINVAL;
+		free(clear_iso_params.table);
+		free(cash_config->exposure_times);
+		goto rgbc_end;
+	}
+
+	do {
+		clear_iso_params.num_steps++;
+		tbl_entry = &clear_iso_params.table[clear_iso_params.num_steps];
+
+		tbl_entry->input_val = (int)strtol(mend, &mend, 10);
+		tbl_entry->output_val = (int)strtol(fend, &fend, 10);
+
+		/* We've reached the end, farewell! */
+		if (tbl_entry->input_val == 0 || tbl_entry->output_val == 0) {
+			break;
+		}
+	} while (clear_iso_params.num_steps < CASH_MAX_POLYREG_TBL_ENTRIES);
+
+	/*
+	 * Store exposure times found in the XML
+	 * The times are stored in a list similar to clear and ISO values
+	 */
+	exposure_time = &cash_config->exposure_times[cash_config->nexposure_times];
+	*exposure_time = (int32_t)strtol(exposure_times, &mend, 10);
+	if (exposure_time == 0) {
+		ret = -EINVAL;
+		free(clear_iso_params.table);
+		free(cash_config->exposure_times);
+		goto rgbc_end;
+	}
+
+	do {
+		cash_config->nexposure_times++;
+		exposure_time = &cash_config->exposure_times[cash_config->nexposure_times];
+		*exposure_time = (int32_t)strtol(mend, &mend, 10);
+
+		/* We've reached the end, farewell! */
+		if (exposure_time == 0) {
+			break;
+		}
+	} while (cash_config->nexposure_times < CASH_MAX_POLYREG_TBL_ENTRIES);
+
+	/* All ok! */
+	cash_rgbc_clear_iso->num_steps = clear_iso_params.num_steps;
+	cash_rgbc_clear_iso->table = clear_iso_params.table;
+
+	/* These configurations are not mandatory */
+	tmp = (int32_t)strtol(rgbc_clear_min, NULL, 10);
+	if (tmp != 0) {
+		cash_config->rgbc_clear_min = tmp;
+	}
+
+	tmp = (int32_t)strtol(rgbc_clear_max, NULL, 10);
+	if (tmp != 0) {
+		cash_config->rgbc_clear_max = tmp;
+	}
+
+	tmp = (int32_t)strtol(rgbc_polyreg_degree, NULL, 10);
+	if (tmp != 0) {
+		cash_config->rgbc_polyreg_degree = tmp;
+	}
+
+	tmp = (int32_t)strtol(rgbc_polyreg_extra, NULL, 10);
+	if (tmp != 0) {
+		cash_config->rgbc_polyreg_extra = tmp;
+	}
+
+rgbc_end:
+	free(buf);
+rgbc_secfail:
 	close(fd);
 	XML_ParserFree(pa);
 


### PR DESCRIPTION
Add a new module that implements basic functionality to control the power state of the sensor and read its values through an input device.
The primary goal is to read the value of the clear channel to get an estimation of the amount of lighting in the scene visible to the back camera.
If the clear value is in the range where camera fails to ramp up brightness, then an ISO value is calcuated from the clear value according to the configuration provided.
ISO value ranges are mapped to fixed exposure times, so CASH is able to inform the camera HAL of both ISO and exposure time to brighten up the scene to an acceptable level.
Due to this, it is also needed to adjust common CASH code to not only return integers through the socket, but structs that contain multiple fields to accomodate for the tuple of ISO and exposure time.
