### PR TITLE
[master] Android.mk: Use PRODUCT_PLATFORM_SOD as build barrier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+ifeq ($(PRODUCT_PLATFORM_SOD),true)
+
 LOCAL_PATH := $(call my-dir)
 
 include $(CLEAR_VARS)
@@ -44,3 +46,5 @@ LOCAL_MODULE_OWNER := sony
 LOCAL_PROPRIETARY_MODULE := true
 
 include $(BUILD_SHARED_LIBRARY)
+
+endif


### PR DESCRIPTION
Use this build barrier to avoid unnecessary inclusion
during the build for non-Sony devices.

Signed-off-by: Pavel Dubrova <pashadubrova@gmail.com>