### PR TITLE
cash_input_common: Properly close threads

### DIFF
--- a/cash_input_common.c
+++ b/cash_input_common.c
@@ -36,7 +36,11 @@ int cash_input_threadman(bool start, struct thread_data *thread_data)
 	int thread_no = thread_data->thread_no;
 
 	if (start == false) {
+		static void *join_retval;  // Unused
+		/* Instruct thread to stop: */
 		cash_thread_run[thread_no] = false;
+		/* Wait until thread really exits: */
+		pthread_join(cash_pthreads[thread_no], join_retval);
 		return 0;
 	};
 


### PR DESCRIPTION
When switching camera modes, the following behaviour can occur:
Not waiting for a thread to exit but immediately reassigning the pointer to another thread can result in zombie processes that interfere with the reading operations.

Use `pthread_join()` to let cashsvr wait until the tof/rgbc thread has exited.