### PR TITLE
[CASH] ToF: Judge 0mm as invalid reading

### DIFF
--- a/cashsvr_input_tof.c
+++ b/cashsvr_input_tof.c
@@ -288,7 +288,7 @@ again:
 					}
 					break;
 				case ABS_HAT1X:
-					if (value < 9000 && value >= 0) {
+					if (value < 9000 && value > 0) {
 						stmvl_cur->range_mm = value;
 						rr = true;
 					}
@@ -357,7 +357,7 @@ int cash_input_tof_thr_read(struct cash_vl53l0 *stmvl_cur,
 				}
 				break;
 			case ABS_HAT1X:
-				if (value < 9000 && value >= 0) {
+				if (value < 9000 && value > 0) {
 					stmvl_cur->range_mm = value;
 					rr = true;
 				}


### PR DESCRIPTION
Sometimes, when lighting is very bright, the STM VL53L0 sensor
will report 0mm without errors on the ranging status.

Noone will ever take a picture when the device is *touching* the
object, so it is safe to judge the 0mm reading as bad reading
and retry.