### PR TITLE
[CASH] Implement sensors calibration from MiscTA parameters

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -24,6 +24,7 @@ include $(BUILD_COPY_HEADERS)
 
 include $(CLEAR_VARS)
 LOCAL_SRC_FILES := cashsvr.c cash_input_common.c cashsvr_input_tof.c cashsvr_input_rgbc.c expatparser.c
+LOCAL_SRC_FILES += cashsvr_input_miscta_params.c
 LOCAL_C_INCLUDES := external/expat/lib
 LOCAL_SHARED_LIBRARIES := liblog libcutils libexpat libpolyreg
 LOCAL_MODULE := cashsvr

--- a/cash_input_common.h
+++ b/cash_input_common.h
@@ -19,6 +19,9 @@
  * limitations under the License.
  */
 
+#include <sys/poll.h>
+#include <sys/epoll.h>
+
 #define ITERATE_MAX_DEVS	9
 
 enum thread_number {
@@ -51,4 +54,4 @@ static const char devfs_input_str[] = "/dev/input/event";
 
 int cash_input_threadman(bool start, struct thread_data *thread_data);
 int cash_set_parameter(char* path, char* value, int value_len);
-
+int cash_set_permissions(char* fpath, char* str_uid, char* str_gid);

--- a/cash_input_rgbc.h
+++ b/cash_input_rgbc.h
@@ -31,5 +31,5 @@ struct cash_tcs3490 {
 int cash_rgbc_read_inst(struct cash_tcs3490 *tcsvl_final);
 int cash_input_rgbc_start(bool start);
 bool cash_input_is_rgbc_alive(void);
-int cash_input_rgbc_init(void);
+int cash_input_rgbc_init(struct cash_tamisc_calib_params *calib_params);
 

--- a/cash_input_tof.h
+++ b/cash_input_tof.h
@@ -44,5 +44,5 @@ int cash_tof_thr_read_stabilized(
 	int runs, int nmatch, int sleep_ms, int hyst);
 int cash_input_tof_start(bool start);
 bool cash_input_is_tof_alive(void);
-int cash_input_tof_init(void);
+int cash_input_tof_init(struct cash_tamisc_calib_params *calib_params);
 

--- a/cash_private.h
+++ b/cash_private.h
@@ -27,6 +27,16 @@
 #define CASHSERVER_TOF_CONF_FILE	"/vendor/etc/tof_focus_calibration.xml"
 #define CASHSERVER_RGBC_CONF_FILE	"/vendor/etc/cash_expcol_calibration.xml"
 
+#define CASHSERVER_DATASTORE_DIR	"/data/vendor/cashsvr/"
+#define CASHSERVER_CALDATA_FILE		CASHSERVER_DATASTORE_DIR "miscta_caldata.bin"
+
+#define CASHSERVER_LIB_TA		"libta.so"
+#define TA_UNIT_RGBCIR_CAPS1		4880
+#define TA_UNIT_RGBCIR_CAPS2		4881
+#define TA_UNIT_TOF_SPAD_NUM		4882
+#define TA_UNIT_TOF_SPAD_TYPE		4883
+#define TA_UNIT_TOF_UM_OFFSET		4884
+
 typedef enum {
 	OP_INITIALIZE = 0,
 	OP_TOF_START,
@@ -78,6 +88,14 @@ struct cash_params {
 	int32_t value;
 };
 
+struct cash_tamisc_calib_params {
+	uint16_t rgbcir_caps1[5];
+	uint16_t rgbcir_caps2[5];
+	uint32_t tof_um_offset;
+	uint32_t tof_spad_num;
+	uint8_t tof_spad_type;
+};
+
 struct cash_response {
 	bool retval;
 	int32_t focus_step;
@@ -92,6 +110,8 @@ int parse_cash_tof_xml_data(char* filepath, char* node,
 int parse_cash_rgbc_xml_data(char* filepath, char* node, 
 			struct cash_polyreg_params *cash_rgbc_clear_iso,
 			struct cash_configuration *cash_config);
+
+int cash_miscta_init_params(struct cash_tamisc_calib_params *conf);
 
 #define REPLY_FOCUS_CUSTOM_LEN		7
 #define REPLY_SHORT_FOCUS_LEN		2

--- a/cashsvr.c
+++ b/cashsvr.c
@@ -477,6 +477,7 @@ static int cash_clear_iso_get_coeff(void)
 int cashsvr_configure(void)
 {
         char propbuf[PROPERTY_VALUE_MAX];
+	struct cash_tamisc_calib_params calib_params;
 	int rc = 0;
 
 	cash_conf.tof_min = 0;
@@ -493,12 +494,18 @@ int cashsvr_configure(void)
 	cash_conf.rgbc_polyreg_extra = 0;
 	cash_conf.disable_rgbc = 0;
 
+	/*
+	 * Retrieve the calibration data either from MiscTA
+	 * or from CASH's calibration file
+	 */
+	cash_miscta_init_params(&calib_params);
+
 	rc = parse_cash_tof_xml_data(CASHSERVER_TOF_CONF_FILE, "tof_focus",
 				&focus_conf, &cash_conf);
 	if (rc < 0) {
 		ALOGE("Cannot parse configuration for ToF assisted AF");
 	} else {
-		rc = cash_input_tof_init();
+		rc = cash_input_tof_init(&calib_params);
 		if (rc < 0)
 			ALOGW("Cannot open ToF. Ranging will be unavailable");
 		cash_autofocus_get_coeff();
@@ -529,7 +536,7 @@ int cashsvr_configure(void)
 	if (rc < 0) {
 		ALOGE("Cannot parse configuration for RGBC assisted AE");
 	} else {
-		rc = cash_input_rgbc_init();
+		rc = cash_input_rgbc_init(&calib_params);
 		if (rc < 0)
 			ALOGW("Cannot open RGBC. Exposure control will be unavailable");
 		cash_clear_iso_get_coeff();

--- a/cashsvr_input_miscta_params.c
+++ b/cashsvr_input_miscta_params.c
@@ -1,0 +1,225 @@
+/*
+ * CASH! Camera Augmented Sensing Helper
+ * a multi-sensor camera helper server
+ *
+ * Copyright (C) 2018-2019 AngeloGioacchino Del Regno <kholk11@gmail.com>
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#define LOG_TAG                 "CASH_MISCTA_READER"
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <sys/un.h>
+#include <dlfcn.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <string.h>
+#include <pthread.h>
+#include <errno.h>
+#include <assert.h>
+#include <string.h>
+#include <unistd.h>
+#include <linux/input.h>
+
+#include <cutils/android_filesystem_config.h>
+#include <log/log.h>
+
+#include "cash_private.h"
+#include "cash_input_common.h"
+#include "cash_ext.h"
+
+struct miscta_link {
+	void *ta_handle;
+	int (*ta_open)(uint8_t p, uint8_t m, uint8_t c);
+	int (*ta_close)(void);
+	int (*ta_getsize)(uint32_t id, uint32_t *size);
+	int (*ta_read)(uint32_t id, void *buf, uint32_t size);
+};
+static struct miscta_link miscta_lnk;
+
+static int cash_miscta_wire_up(void)
+{
+	miscta_lnk.ta_handle = dlopen(CASHSERVER_LIB_TA, RTLD_NOW);
+	if (!miscta_lnk.ta_handle) {
+		ALOGE("%s: DLOPEN failed for %s", __func__, CASHSERVER_LIB_TA);
+		return -1;
+	}
+
+	miscta_lnk.ta_open = dlsym(miscta_lnk.ta_handle, "ta_open");
+	if (!miscta_lnk.ta_open) {
+		ALOGE("%s: DLSYM failed for ta_open", __func__);
+		return -1;
+	}
+
+	miscta_lnk.ta_close = dlsym(miscta_lnk.ta_handle, "ta_close");
+	if (!miscta_lnk.ta_close) {
+		ALOGE("%s: DLSYM failed for ta_close", __func__);
+		return -1;
+	}
+
+	miscta_lnk.ta_getsize = dlsym(miscta_lnk.ta_handle, "ta_getsize");
+	if (!miscta_lnk.ta_open) {
+		ALOGE("%s: DLSYM failed for ta_getsize", __func__);
+		return -1;
+	}
+
+	miscta_lnk.ta_read = dlsym(miscta_lnk.ta_handle, "ta_read");
+	if (!miscta_lnk.ta_read) {
+		ALOGE("%s: DLSYM failed for ta_read", __func__);
+		return -1;
+	}
+
+	return 0;
+}
+
+static int cash_miscta_read_unit(uint32_t id, void *data_out)
+{
+	uint32_t ta_unit_sz = 0;
+	int rc;
+
+	rc = miscta_lnk.ta_getsize(id, &ta_unit_sz);
+	if (ta_unit_sz == 0) {
+		ALOGE("FATAL: Cannot get MiscTA unit %u size", id);
+		return -1;
+	};
+
+	rc = miscta_lnk.ta_read(id, data_out, ta_unit_sz);
+	if (rc) {
+		ALOGE("WARNING: MiscTA unit %u read returns %d", id, rc);
+	};
+
+	return 0;
+}
+
+/*
+ * cash_miscta_read_store_params - Read configuration from MiscTA and
+ *				   store it to the CASH data file
+ *
+ * Call this function with force == true to force params read and
+ * store even if the calibration file already exists.
+ */
+static int cash_miscta_read_store_params(bool force)
+{
+	struct cash_tamisc_calib_params tacfg;
+	struct stat st = {0};
+	bool read_error = false, set_perm = false;
+	int rc, fd, i;
+
+	/* Check if the file exists to eventually set the owner */
+	if (stat(CASHSERVER_CALDATA_FILE, &st) == -1) {
+		set_perm = true;
+	} else if (!force) {
+		/* If file exists and not forcing re-read, just exit. */
+		return 0;
+	}
+
+	fd = open(CASHSERVER_CALDATA_FILE, O_WRONLY | O_CREAT, 0664);
+	if (fd < 0) {
+		ALOGE("FATAL: Cannot open/create %s", CASHSERVER_CALDATA_FILE);
+		return -1;
+	}
+
+	if (set_perm) {
+		/* Set owner on the file, if it has been just created */
+		rc = cash_set_permissions(CASHSERVER_CALDATA_FILE,
+						"system", "input");
+		if (rc == -1)
+			return -1;
+	}
+
+	/* Wire up the function pointers */
+	rc = cash_miscta_wire_up();
+	if (rc)
+		return rc;
+
+	/* This can be painfully slow */
+	for (i = 0; i < 12; i++) {
+		rc = miscta_lnk.ta_open(2, 0x1, 1);
+		if (!rc)
+			break;
+
+		sleep(5);
+	}
+	if (rc) {
+		ALOGE("FATAL: Cannot open MiscTA");
+		return -1;
+	}
+
+	rc = 0;
+
+	rc = cash_miscta_read_unit(TA_UNIT_RGBCIR_CAPS1, &tacfg.rgbcir_caps1);
+	rc += cash_miscta_read_unit(TA_UNIT_RGBCIR_CAPS2, &tacfg.rgbcir_caps2);
+	if (rc) {
+		ALOGE("FATAL: Cannot read RGBCIR config from MiscTA\n");
+		read_error = true;
+	}
+
+	/* Number of SPADs */
+	rc = cash_miscta_read_unit(TA_UNIT_TOF_SPAD_NUM, &tacfg.tof_spad_num);
+
+	/* Type of SPADs: Aperture Type == 1 - Non-Aperture Type == 0 */
+	rc += cash_miscta_read_unit(TA_UNIT_TOF_SPAD_TYPE,
+					&tacfg.tof_spad_type);
+
+	/* Calibration Data offset, expressed in micrometers */
+	rc += cash_miscta_read_unit(TA_UNIT_TOF_UM_OFFSET,
+					&tacfg.tof_um_offset);
+	if (rc) {
+		ALOGE("FATAL: Cannot read ToF config from MiscTA\n");
+		ALOGE("Your ToF sensor may work suboptimally.\n");
+		read_error = true;
+	}
+
+	miscta_lnk.ta_close();
+
+	/* Write the struct into the calibration file */
+	write(fd, &tacfg, sizeof(struct cash_tamisc_calib_params));
+	close(fd);
+
+	if (read_error)
+		return -1;
+
+	return rc;
+}
+
+int cash_miscta_init_params(struct cash_tamisc_calib_params *conf)
+{
+	struct stat st = {0};
+	int ret, fd;
+
+	/* The folder has to be created in OS init scripts. */
+	ret = stat(CASHSERVER_DATASTORE_DIR, &st);
+	if (ret == -1) {
+		ALOGW("%s does not exist. Bailing out.",
+				CASHSERVER_DATASTORE_DIR);
+		return -1;
+	}
+
+	ret = cash_miscta_read_store_params(false);
+	if (ret)
+		return ret;
+
+	fd = open(CASHSERVER_CALDATA_FILE, O_RDONLY);
+	if (fd < 0)
+		return -1;
+
+	read(fd, conf, sizeof(struct cash_tamisc_calib_params));
+	close(fd);
+
+	return 0;
+}

--- a/vendor/etc/init/cashsvr.rc
+++ b/vendor/etc/init/cashsvr.rc
@@ -1,6 +1,7 @@
 on post-fs-data
-    # create socket for cashsvr
+    # create socket and data directory for cashsvr
     mkdir /dev/socket/cashsvr 0755 system system
+    mkdir /data/vendor/cashsvr 0755 root system
 
 on property:sys.boot_completed=1
     start cashsvr


### PR DESCRIPTION
This commit implements reading the sensors calibration from
their specific MiscTA units and stores them to a file in
the /data/misc/cashsvr/ directory, to avoid opening the TA
at every boot, which can be painfully slow.

This currently reads the parameters for both RGBCIR and
ToF sensors (currently, TCS3490 and STM VL53L0X), but will
only use the parameters for the ToF sensor - for now.

The parameters are sent to the ToF sensor currently via
sysfs are:
- Number of SPADs (type is fixed to not-aperture)
- Ranging offset calibration, expressed in micrometers

These parameters are required because, obviously, the
sensor sits behind a glass window.