### PR TITLE
fixup! Android.mk: Replace LOCAL_COPY_HEADERS, add CleanSpec.mk

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -33,7 +33,7 @@ include $(CLEAR_VARS)
 LOCAL_HEADER_LIBRARIES := libhardware_headers
 # Export cash_ext.h to any module that links to libcashctl,
 # e.g. in vendor/qcom/opensource/camera
-LOCAL_EXPORT_C_INCLUDES := $(LOCAL_PATH)/include
+LOCAL_EXPORT_C_INCLUDE_DIRS := $(LOCAL_PATH)/include
 LOCAL_C_INCLUDES += $(LOCAL_PATH)/include/cashsvr
 LOCAL_SRC_FILES := cash_ctl.c
 LOCAL_SHARED_LIBRARIES := \

--- a/CleanSpec.mk
+++ b/CleanSpec.mk
@@ -1,0 +1,54 @@
+# Copyright (C) 2007 The Android Open Source Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# If you don't need to do a full clean build but would like to touch
+# a file or delete some intermediate files, add a clean step to the end
+# of the list.  These steps will only be run once, if they haven't been
+# run before.
+#
+# E.g.:
+#     $(call add-clean-step, touch -c external/sqlite/sqlite3.h)
+#     $(call add-clean-step, rm -rf $(PRODUCT_OUT)/obj/STATIC_LIBRARIES/libz_intermediates)
+#
+# Always use "touch -c" and "rm -f" or "rm -rf" to gracefully deal with
+# files that are missing or have been moved.
+#
+# Use $(PRODUCT_OUT) to get to the "out/target/product/blah/" directory.
+# Use $(OUT_DIR) to refer to the "out" directory.
+#
+# If you need to re-do something that's already mentioned, just copy
+# the command and add it to the bottom of the list.  E.g., if a change
+# that you made last week required touching a file and a change you
+# made today requires touching the same file, just copy the old
+# touch step and add it to the end of the list.
+#
+# ************************************************
+# NEWER CLEAN STEPS MUST BE AT THE END OF THE LIST
+# ************************************************
+
+# For example:
+#$(call add-clean-step, rm -rf $(OUT_DIR)/target/common/obj/APPS/AndroidTests_intermediates)
+#$(call add-clean-step, rm -rf $(OUT_DIR)/target/common/obj/JAVA_LIBRARIES/core_intermediates)
+#$(call add-clean-step, find $(OUT_DIR) -type f -name "IGTalkSession*" -print0 | xargs -0 rm -f)
+#$(call add-clean-step, rm -rf $(PRODUCT_OUT)/data/*)
+
+
+# Android 10: Remove legacy headers from LOCAL_COPY_HEADERS
+$(call add-clean-step, rm -rf $(TARGET_OUT_HEADERS)/cashsvr)
+
+
+# ************************************************
+# NEWER CLEAN STEPS MUST BE AT THE END OF THE LIST
+# ************************************************


### PR DESCRIPTION
Ashes on my head. And may ancient curses befall those who devised such inconsistent variable naming.
https://github.com/sonyxperiadev/vendor-sony-oss-cash/pull/15#issuecomment-622189681

---

Also added a `CleanSpec.mk` file so that old headers are cleaned and not mistakenly picked up.